### PR TITLE
Add one missing concept to Othaniel-2017-300

### DIFF
--- a/concepticondata/conceptlists/Othaniel-2017-300.tsv
+++ b/concepticondata/conceptlists/Othaniel-2017-300.tsv
@@ -292,6 +292,7 @@ Othaniel-2017-300-290	290	wipe	1454	WIPE
 Othaniel-2017-300-291	291	witchcraft	392	MAGIC
 Othaniel-2017-300-292	292	woman	962	WOMAN
 Othaniel-2017-300-293	293	word/speech		
+Othaniel-2017-300-294	294	work	984	WORK (LABOUR)
 Othaniel-2017-300-295	295	write	1672	WRITE
 Othaniel-2017-300-296	296	year	1226	YEAR
 Othaniel-2017-300-297	297	yell	715	SHOUT


### PR DESCRIPTION
# Pull request checklist

- [ ] add new concept list
- [ ] add new metadata
- [ ] add new Concepticon concept sets
- [ ] add new Concepticon concept relations
- [ ] refine existing Concepticon concept set mappings
- [ ] refine Concepticon glosses
- [ ] refine Concepticon concept relations
- [ ] refine Concepticon concept definitions
- [ ] retire data

## Additional information
While working on the Othaniel's dataset for the Lexibank, I've noticed one awkward mistake I made back then with the concept list. It is supposed to have 300 concepts but for some reason, I happened to delete one line with the 'work' gloss. The list used to look like this:
|ID|NUMBER|ENGLISH|CONCEPTICON_ID|CONCEPTICON_GLOSS|
|--|--|--|--|--|
|..|..|..|..|..|
|Othaniel-2017-300-293|293|word/speech| | |
|Othaniel-2017-300-295|295|write|1672|WRITE|


I added the missing concept back to the list. No ID has suffered from this change.