### PR TITLE
Correct HORN mapping in Lieberherr-2017-100

### DIFF
--- a/concepticondata/conceptlists/Lieberherr-2017-100.tsv
+++ b/concepticondata/conceptlists/Lieberherr-2017-100.tsv
@@ -44,7 +44,7 @@ Lieberherr-2017-100-42	42	to hear	1408	HEAR
 Lieberherr-2017-100-43	43	heavy	1210	HEAVY
 Lieberherr-2017-100-44	44	to hide	2486	HIDE
 Lieberherr-2017-100-45	45	to kill	1417	KILL
-Lieberherr-2017-100-46	46	horn	124	THORN
+Lieberherr-2017-100-46	46	horn	1393	HORN (ANATOMY)
 Lieberherr-2017-100-47	47	house	1252	HOUSE
 Lieberherr-2017-100-48	48	in	1460	IN
 Lieberherr-2017-100-49	49	knee	1371	KNEE


### PR DESCRIPTION
# Pull request checklist

- [ ] add new concept list
- [ ] add new metadata
- [ ] add new Concepticon concept sets
- [ ] add new Concepticon concept relations
- [x] refine existing Concepticon concept set mappings
- [ ] refine Concepticon glosses
- [ ] refine Concepticon concept relations
- [ ] refine Concepticon concept definitions
- [ ] retire data

## Additional information

Horn was incorrectly mapped to `THORN`.
