### PR TITLE
patch pharao's worldist

### DIFF
--- a/concepticondata/conceptlists/PharaoHansen-2020-100.tsv
+++ b/concepticondata/conceptlists/PharaoHansen-2020-100.tsv
@@ -11,7 +11,7 @@ PharaoHansen-2020-100-9	9	Nuevo	New	1231	NEW	Nuevo
 PharaoHansen-2020-100-10	10	Bueno	Good	1035	GOOD	Bueno
 PharaoHansen-2020-100-11	11	Pesado	Heavy	1210	HEAVY	Pesado
 PharaoHansen-2020-100-12	12	Seco	Dry	1398	DRY	Seco
-PharaoHansen-2020-100-13	13	Frío (hace frío)	Cold (it’s cold)	2483	COLD (OF WEATHER)	Frio (hace frio)
+PharaoHansen-2020-100-13	13	Frío (hace frío)	Cold (it’s cold)	2483	COLD (OF WEATHER)	Frio(hace frio) // Frio (hace frio)
 PharaoHansen-2020-100-14	14	Caliente	Hot	1286	HOT	Caliente
 PharaoHansen-2020-100-15	15	Mujer	Woman	962	WOMAN	Mujer
 PharaoHansen-2020-100-16	16	Hombre	Man	1554	MAN	Hombre
@@ -79,7 +79,7 @@ PharaoHansen-2020-100-77	77	Agua	Water	948	WATER	Agua
 PharaoHansen-2020-100-78	78	Viento	Wind	960	WIND	Viento
 PharaoHansen-2020-100-79	79	Lluvia	Rain (n)	658	RAIN (PRECIPITATION)	Llúvia
 PharaoHansen-2020-100-80	80	Nieve/hielo	Snow (n)	784	SNOW	Nieve/hielo
-PharaoHansen-2020-100-81	81	Piedra	Stone	857	STONE	Piedra
+PharaoHansen-2020-100-81	81	Piedra	Stone	857	STONE	piedra // Piedra
 PharaoHansen-2020-100-82	82	arena	Sand	671	SAND	Arena
 PharaoHansen-2020-100-83	83	tierra	Earth	1228	EARTH (SOIL)	Tierra
 PharaoHansen-2020-100-84	84	sal	Salt	1274	SALT	Sal

--- a/concepticondata/conceptlists/PharaoHansen-2020-100.tsv-metadata.json
+++ b/concepticondata/conceptlists/PharaoHansen-2020-100.tsv-metadata.json
@@ -48,6 +48,7 @@
                     },
                     {
                         "datatype": "string", 
+			"separator": " // ",
                         "name": "GLOSS_IN_DATA"
                     }
                 ], 


### PR DESCRIPTION
# Pull request checklist

- [ ] add new concept list
- [ ] add new metadata
- [ ] add new Concepticon concept sets
- [ ] add new Concepticon concept relations
- [ ] refine existing Concepticon concept set mappings
- [ ] refine Concepticon glosses
- [ ] refine Concepticon concept relations
- [ ] refine Concepticon concept definitions
- [ ] retire data

## Additional information

This is a patch in the metadata, adding a separator for `gloss_in_source`, wheere we have ambiguous glosses. @CarolinHu, if you could quickly confirm this? I think there is no error here, just two more glosses due to ambiguous data (only gloss_in_source).
