### PR TITLE
smart as property

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -95,6 +95,7 @@ Robert Blust | D | 1.0
 Sandra Auderset | LG | 2.4
 Sean Lee | D | 1.0
 Sebastian Nicolai | CMS | 1.0
+Stéphane Polis | P | 2.5 
 Sylvia Li | C | 2.4
 Taraka Rama | MSDCG | 2.4
 Thiago Chacon | MSD | 1.0, 1.1, 2.3

--- a/concepticondata/concepticon.tsv
+++ b/concepticondata/concepticon.tsv
@@ -2528,7 +2528,7 @@ ID	GLOSS	SEMANTICFIELD	DEFINITION	ONTOLOGICAL_CATEGORY	REPLACEMENT_ID
 2527	ABILITY	Social and political relations	Capacity to do specific things.	Person/Thing	
 2528	SIZE (OF PERSON)	Spatial relations	The height of a person or an animal.	Person/Thing	
 2529	BLESSED	Religion and belief	To have received blessing.	Person/Thing	
-2530	SMART	Emotions and values	To be of high intelligence.	Person/Thing	
+2530	SMART	Emotions and values	To be of high intelligence.	Property	
 2531	BROAD	Spatial relations	Having a large width.	Property	
 2532	TORNADO	The physical world	A violently rotating column of air that is in contact with both the surface of the earth and a cumulonimbus cloud or, in rare cases, the base of a cumulus cloud.	Person/Thing	
 2533	WATERSIDE	The physical world	The margin or shore of a river, lake, or ocean.	Person/Thing	113


### PR DESCRIPTION
# Pull request checklist

- [ ] add new concept list
- [ ] add new metadata
- [ ] add new Concepticon concept sets
- [ ] add new Concepticon concept relations
- [ ] refine existing Concepticon concept set mappings
- [ ] refine Concepticon glosses
- [ ] refine Concepticon concept relations
- [x] refine Concepticon concept definitions
- [ ] retire data

## Additional information

Stéphane Polis pointet me to this problem: smart was listed as a Person/Thing, but should be a property.

I'll use my privileges to merge this after testing without review.
