### PR TITLE
Fix lexirumah concept

### DIFF
--- a/concepticondata/conceptlists/Klamer-2018-607.tsv
+++ b/concepticondata/conceptlists/Klamer-2018-607.tsv
@@ -430,7 +430,7 @@ Klamer-2018-607-428	428	bathe (a child)	to_bathe_a_child	176	3170	BATHE (SOMEONE
 Klamer-2018-607-429	429	be silent	to_be_silent	109	48	BE SILENT
 Klamer-2018-607-430	430	bite	to_bite	328	1403	BITE
 Klamer-2018-607-431	431	bless	to_bless	56	391	BLESS
-Klamer-2018-607-432	432	blow	to_blow	265	175	BLOW (OF WIND)
+Klamer-2018-607-432	432	blow	to_blow	265	176	BLOW (WITH MOUTH)
 Klamer-2018-607-433	433	borrow	to_borrow	96	1823	BORROW
 Klamer-2018-607-434	434	breathe	to_breathe	238	1407	BREATHE
 Klamer-2018-607-435	435	burn (clear land)	to_burn_clear_land	322	3539	BURN LAND


### PR DESCRIPTION
‘to blow’ is listed in the bodily actions in the original wordlist, cf. the discussion in https://github.com/lessersunda/lexirumah-data/issues/123

- [X] refine existing Concepticon concept set mappings
