### PR TITLE
update description for cassava

### DIFF
--- a/concepticondata/concepticon.tsv
+++ b/concepticondata/concepticon.tsv
@@ -923,7 +923,7 @@ ID	GLOSS	SEMANTICFIELD	DEFINITION	ONTOLOGICAL_CATEGORY	REPLACEMENT_ID
 922	PEAR	Agriculture and vegetation	A fruit produced by the pear tree.	Person/Thing	
 923	LOVE	Emotions and values	To have an intense feeling of affection and care towards another person.	Action/Process	
 924	VEGETABLES	Food and drink	Any of various herbaceous plants having parts that are used as food.	Person/Thing	
-925	CASSAVA	Agriculture and vegetation	A starchy pulp made with the roots of the cassava plant.	Person/Thing	
+925	CASSAVA	Agriculture and vegetation	Shrub (Manihot esculenta) whose roots are rich in starch.	Person/Thing	
 926	RICE	Agriculture and vegetation	Seeds of the rice plant (Oryza sativa) used as food.	Person/Thing	
 927	MANIOC	Agriculture and vegetation	Shrub (Manihot esculenta) whose roots are rich in starch.	Person/Thing	925
 928	EMBRACE	Emotions and values	To squeeze someone in one's arms.	Action/Process	


### PR DESCRIPTION
# Pull request checklist

- [ ] add new concept list
- [ ] add new metadata
- [ ] add new Concepticon concept sets
  * [ ] checked whether the new concept(s) can be applied to existing lists with
    `concepticon notlinked --gloss "NEW_GLOSS"`
- [ ] add new Concepticon concept relations
- [ ] refine existing Concepticon concept set mappings
- [ ] refine Concepticon glosses
- [ ] refine Concepticon concept relations
- [x] refine Concepticon concept definitions
- [ ] retire data

## Additional information

This PR updates the description of 925 `CASSAVA` with the description of 927 `MANIOC`. The latter was superseeded by the former and the description should be adapted to be more general. Based on #1182 