### PR TITLE
Mapped call out to 715 SHOUT

### DIFF
--- a/concepticondata/conceptlists/Greenhill-2015-2525.tsv
+++ b/concepticondata/conceptlists/Greenhill-2015-2525.tsv
@@ -312,7 +312,7 @@ Greenhill-2015-2525-799	799	garden	586	GARDEN
 Greenhill-2015-2525-801	801	penis	1222	PENIS
 Greenhill-2015-2525-802	802	lizard	632	LIZARD
 Greenhill-2015-2525-804	804	purposive verb suffix		
-Greenhill-2015-2525-805	805	to call out		
+Greenhill-2015-2525-805	805	to call out	715	SHOUT
 Greenhill-2015-2525-806	806	navel	1838	NAVEL
 Greenhill-2015-2525-807	807	trunk (of tree)	776	TRUNK OF TREE
 Greenhill-2015-2525-808	808	yesterday, tomorrow		

--- a/concepticondata/conceptlists/Klamer-2018-607.tsv
+++ b/concepticondata/conceptlists/Klamer-2018-607.tsv
@@ -436,7 +436,7 @@ Klamer-2018-607-434	434	breathe	to_breathe	238	1407	BREATHE
 Klamer-2018-607-435	435	burn (clear land)	to_burn_clear_land	322	3539	BURN LAND
 Klamer-2018-607-436	436	bury	to_bury	129	1719	BURY
 Klamer-2018-607-437	437	buy	to_buy	192	1869	BUY
-Klamer-2018-607-438	438	call out	to_call_out	177	1084	CALL
+Klamer-2018-607-438	438	call out	to_call_out	177	715	SHOUT
 Klamer-2018-607-439	439	chase; run after	to_chase_away_to_run_after	113		
 Klamer-2018-607-440	440	chew	to_chew	181	321	CHEW
 Klamer-2018-607-441	441	choose	to_choose	185	1750	CHOOSE

--- a/concepticondata/conceptlists/Robinson-2012-398.tsv
+++ b/concepticondata/conceptlists/Robinson-2012-398.tsv
@@ -44,7 +44,7 @@ NUMBER	ID	ENGLISH	CONCEPTICON_ID	CONCEPTICON_GLOSS
 43	Robinson-2012-398-43	burn/shine	2102	BURN
 44	Robinson-2012-398-44	butterfly	1791	BUTTERFLY
 45	Robinson-2012-398-45	buy	1869	BUY
-46	Robinson-2012-398-46	call out		
+46	Robinson-2012-398-46	call out	715	SHOUT	
 47	Robinson-2012-398-47	canoe	1970	CANOE
 48	Robinson-2012-398-48	cassava	925	CASSAVA
 49	Robinson-2012-398-49	chase away/expel	30	DISPEL

--- a/concepticondata/conceptlists/Zgraggen-1980-380.tsv
+++ b/concepticondata/conceptlists/Zgraggen-1980-380.tsv
@@ -297,7 +297,7 @@ Zgraggen-1980-380-364	897	SWALLOW	364	swallow
 Zgraggen-1980-380-365	1749	TAKE	365	take
 Zgraggen-1980-380-366a	1917	TIE	366a	tie
 Zgraggen-1980-380-366b	1094	FASTEN	366b	fasten
-Zgraggen-1980-380-367			367	call out
+Zgraggen-1980-380-367	715	SHOUT	367	call out
 Zgraggen-1980-380-368	1839	CRY	368	cry
 Zgraggen-1980-380-369	1355	LAUGH	369	laugh
 Zgraggen-1980-380-370a	131	FESTIVAL	370a	singsing


### PR DESCRIPTION
I remapped Klamer-2018-607 and mapped the other instances to 715 SHOUT. See Issue #1198.

# Pull request checklist
- [ ] add new concept list
- [ ] add new metadata
- [ ] add new Concepticon concept sets
  * [ ] checked whether the new concept(s) can be applied to existing lists with
    `concepticon notlinked --gloss "NEW_GLOSS"`
- [ ] add new Concepticon concept relations
- [ ] refine existing Concepticon concept set mappings
- [ ] refine Concepticon glosses
- [ ] refine Concepticon concept relations
- [ ] refine Concepticon concept definitions
- [ ] retire data

## Additional information

...
