### PR TITLE
Updated Bowern-2021-203c

### DIFF
--- a/concepticondata/conceptlists/Bowern-2021-203c.tsv
+++ b/concepticondata/conceptlists/Bowern-2021-203c.tsv
@@ -42,7 +42,7 @@ Bowern-2021-203c-40	40	clothing 	676	culture-mythology	Culture Vocabulary	1895	C
 Bowern-2021-203c-41	41	club 	621	subsistence tool	Culture Vocabulary	1763	CLUB
 Bowern-2021-203c-42	42	club (nulla-nulla) 	774	subsistence tool	Culture Vocabulary		
 Bowern-2021-203c-43	43	coca 	153	flora-fauna	Culture Vocabulary	137	COCA
-Bowern-2021-203c-44	44	coca 	717	narcotics	Culture Vocabulary		
+Bowern-2021-203c-44	44	coca 	717	narcotics	Culture Vocabulary	137	COCA
 Bowern-2021-203c-45	45	cook food 	623	food	Culture Vocabulary	1100	COOK (SOMETHING)
 Bowern-2021-203c-46	46	cook in earth oven 	775	food	Culture Vocabulary		
 Bowern-2021-203c-47	47	corn 	700	food	Culture Vocabulary	506	MAIZE


### PR DESCRIPTION
I've mapped Bowern-2021-203c-44 to COCA, as suggested in the google doc. However, I'm not sure about this as we already have a mapping of COCA in the list, where it is specified that a plant is meant. For Bowern-2021-203c-44 the list specifies it as "narcotics" rather than "flora-fauna", so I suppose they mean a substance won from the plant, instead of the plant itself. Should I unmap this again? 