### PR TITLE
New concepts from West Old Trukic added to master list

### DIFF
--- a/concepticondata/concepticon.tsv
+++ b/concepticondata/concepticon.tsv
@@ -3959,3 +3959,87 @@ ID	GLOSS	SEMANTICFIELD	DEFINITION	ONTOLOGICAL_CATEGORY	REPLACEMENT_ID
 3973	DEPRESSED	Emotions and values	A mental state of despondency, unhappinness, or hopelessness.	Property	
 3974	UNHAPPY	Emotions and values	Feeling not cheerful or glad, sometimes due to a misfortune.	Property	
 3975	NERVOUS	Emotions and values	A mental state of nervousness or agitation. Also, being easily excited or irritated.	Property	
+3976	PIEBALD	Animals	Pattern of unpigmented spots (white) on a pigmented background of hair, feathers or scales	Property
+3977	GANTRY	Basic actions and technology	Overhead bridge-like structure supporting equipment such as a crane, signals, or cameras.	Person/Thing
+3978	CHARISMA	Religion and belief	Compelling attractiveness or charm that can inspire devotion in others	Person/Thing
+3979	BAN (TITLE)	Social and political relations	Noble title used in several states in Central and Southeastern Europe between the 7th century and the 20th century	Person/Thing
+3980	HAIRY	The body	People or animals covered in hairs or fur	Property
+3981	LABEL	Law	Piece of paper, plastic film, cloth, metal, or other material affixed to a container or product, on which is written or printed information or symbols about the product or item	Person/Thing
+3982	VELVET	Clothing and grooming	Type of woven tufted fabric in which the cut threads are evenly distributed, with a short pile, giving it a distinctive soft feel	Person/Thing
+3983	LEGCUFFS	Law	Physical restraints used on the ankles of a person to allow walking only with a restricted stride and to prevent running and effective physical resistance	Person/Thing
+3984	ARCTIUM	Agriculture and Vegetation	Genus of biennial plants commonly known as burdock, family Asteraceae.[2] Native to Europe and Asia, several species have been widely introduced worldwide.[3] Burdock's clinging properties, in addition to thus providing an excellent mechanism for seed dispersal, led to the invention of the hook and loop fastener.	Person/Thing
+3985	STUB	The physical world	Shortened objects and entities	Person/Thing
+3986	MAGICAL	Religion and belief	Of, relating to, or by means of magic	Property
+3987	EUPHORBIA	Agriculture and Vegetation	very large and diverse genus of flowering plants, commonly called spurge, in the spurge family	Person/Thing
+3988	FASTENER	Basic actions and technology	Hardware device that mechanically joins or affixes two or more objects together	Person/Thing
+3989	RHEUM	The body	Thin mucus naturally discharged from the eyes, nose, or mouth, often during sleep	Person/Thing
+3990	BANQUET	Religion and belief	Formal large meal or feast, where a number of people consume food together.	Person/Thing
+3991	COURIER	Social and political relations	Person or organisation that delivers a message, package or letter from one place or person to another place or person.	Person/Thing
+3992	GRIST	Agriculture and Vegetation	Grain that has been separated from its chaff in preparation for grinding	Person/Thing
+3993	WEDGE	Basic actions and technology	Triangular shaped tool, and is a portable inclined plane, and one of the six simple machines	Person/Thing
+3994	ATONE	Law	Taking action to correct previous wrongdoing on their part, either through direct action to undo the consequences of that act, equivalent action to do good for others, or some other expression of feelings of remorse	Action/Process
+3995	MERIT	Possession	A claim to commendation or a reward	Person/Thing
+3996	MORALITY	Religion and belief	Differentiation of intentions, decisions and actions between those that are distinguished as proper (right) and those that are improper (wrong)	Person/Thing
+3997	POLECAT	Animals	Common name for mammals in the order Carnivora and subfamilies Ictonychinae and Mustelinae	Person/Thing
+3998	MATCHMAKER	Social and political relations	Someone who finds suitable dates or marriage partners for other people	Person/Thing
+3999	STEPPE MOUSE	Animals	Species of rodent in the family Muridae	Person/Thing
+4000	BULRUSH	Agriculture and Vegetation	Vernacular name for several large wetland grass-like plants (Cyperaceae, Typhaceae)	Person/Thing
+4001	REIN	Animals	Items of horse tack, used to direct a horse or other animal used for riding	Person/Thing
+4002	BORDERLAND	Social and political relations	Geographical space or zone around a territorial border	Person/Thing
+4003	HORNBEAM	Agriculture and Vegetation	Hardwood trees in the flowering plant genus Carpinus in the birch family Betulaceae	Person/Thing
+4004	CONFESS	Law	To admit to the truth, particularly in the context of sins or crimes committed	Person/Thing
+4005	CUDWEED	Agriculture and Vegetation	Any of many of species of flowering plants in family Asteraceae	Person/Thing
+4006	THIMBLE	Clothing and grooming	Small pitted cup worn on the finger that protects it from being pricked or poked by a needle while sewing	Person/Thing
+4007	MORAL	Religion and belief	Conforming to a standard of right behaviour; sanctioned by or operative on one's conscience or ethical judgment	Person/Thing
+4008	SUITABLE	Miscellaneous function words	Having sufficient or the required properties for a certain purpose or task; appropriate to a certain occasion	Person/Thing
+4009	BUTTERMILK	Food and drink	Fermented dairy drink. Traditionally, it was the liquid left behind after churning butter out of cultured cream	Person/Thing
+4010	DO-LITTLE	Social and political relations	Lazy person; one who does little but does not admit to it	Person/Thing
+4011	STRATIOTES ALOIDES	Agriculture and Vegetation	Commonly known as water soldiers or water pineapple, is a submerged aquatic plant native to Europe and northwestern Asia	Person/Thing
+4012	ACER TATRICUM	Agriculture and Vegetation	Tatar maple or Tatarian maple, is a species of maple widespread across central and southeastern Europe and temperate Asia, from Austria and Turkey east as far as Japan and the Russian Far East	Person/Thing
+4013	MAN OF GRIT	Social and political relations	Man with strength of mind, great courage or fearlessness, fortitude.	Person/Thing
+4014	CHICORY	Agriculture and Vegetation	Somewhat woody, perennial herbaceous plant of the family Asteraceae, usually with bright blue flowers, rarely white or pink	Person/Thing
+4015	MERCURY	Basic actions and technology	Chemical element with the symbol Hg and atomic number 80. It is also known as quicksilver and was formerly named hydrargyrum	Person/Thing
+4016	STOOK	Agriculture and Vegetation	Arrangement of sheaves of cut grain-stalks placed so as to keep the grain-heads off the ground while still in the field and prior to collection for threshing	Person/Thing
+4017	CUD	Agriculture and Vegetation	Portion of food that returns from a ruminant's stomach to the mouth to be chewed for the second time	Person/Thing
+4018	TIMOTHY (GRASS)	Agriculture and Vegetation	Abundant perennial grass native to most of Europe except for the Mediterranean region	Person/Thing
+4019	KOMONDOR	Animals	Also known as the Hungarian sheepdog, is a large, white-coloured Hungarian breed of livestock guardian dog with a long, corded coat	Person/Thing
+4020	BLACKTHORN	Agriculture and Vegetation	Species of flowering plant in the rose family Rosaceae. The species is native to Europe, western Asia, and locally in northwest Africa	Person/Thing
+4021	LOAN	Possession	Lending of money by one or more individuals, organizations, or other entities to other individuals, organizations etc	Person/Thing
+4022	PICUS VIRIDIS	Animals	Large green woodpecker with a bright red crown and a black moustache	Person/Thing
+4023	GOBIO GOBIO	Animals	Or the gudgeon, is a species of fish in the family Cyprinidae. This small fish is widely distributed in fresh-water streams and lakes across central and temperate Eurasia	Person/Thing
+4024	PEN (ENCLOSURE)	Animals	Enclosure for holding livestock. It may also perhaps be used as a term for an enclosure for other animals such as pets that are unwanted inside the house	Person/Thing
+4025	CRUMB	Food and drink	small piece which breaks off from baked food (such as cake, biscuit or bread)	Person/Thing
+4026	POINT (TABLE GAMES)	Social and political relations	Any one of the triangular spaces on a tables board	Person/Thing
+4027	STITCH	Clothing and grooming	To form stitches in; especially, to sew in such a manner as to show on the surface a continuous line of stitches	Action/Process
+4028	ETERNAL	Religion and belief	Lasting forever; unending	Person/Thing
+4029	BECOME MAD	Cognition	To grow crazy	Action/Process
+4030	ORNITHOGALUM	Agriculture and Vegetation	Genus of perennial plants mostly native to southern Europe and southern Africa belonging to the family Asparagaceae	Person/Thing
+4031	LEES	Agriculture and Vegetation	Deposits of dead yeast or residual yeast and other particles that precipitate, or are carried by the action of "fining", to the bottom of a vat of wine after fermentation and aging	Person/Thing
+4032	CORNUS	Agriculture and Vegetation	Genus of about 30–60 species of woody plants in the family Cornaceae, commonly known as dogwoods, which can generally be distinguished by their blossoms, berries, and distinctive bark	Person/Thing
+4033	STIZOSTEDION LUCIOPERCA	Animals	The zander, sander or pikeperch, is a species of ray-finned fish from the family Percidae, which includes the perches, ruffes and darters	Person/Thing
+4034	SCURVY	The body	Disease resulting from a lack of vitamin C (ascorbic acid)	Person/Thing
+4035	MIRAGE	The physical world	Naturally-occurring optical phenomenon in which light rays bend via refraction to produce a displaced image of distant objects or the sky	Person/Thing
+4036	TROUSSEAU BOX	Basic actions and technology	Man made object that contains clothes and linen, etc., that a bride collects or that is given to her for her wedding and married life, especially a traditional or formal set of these	Person/Thing
+4037	GROCER	Social and political relations	Person who retails groceries (foodstuffs and household items) from a grocery	Person/Thing
+4038	SLUMBER	The body	Very light state of sleep, almost awake	Person/Thing
+4039	GYRFALCON	Animals	Largest of the falcon species, is a bird of prey. The abbreviation gyr is also used.[4] It breeds on Arctic coasts and tundra, and the islands of northern North America and the Eurosiberian region	Person/Thing
+4040	FURRIER	Social and political relations	Person who sells, makes, repairs, alters, cleans, or otherwise deals in clothing made of fur	Person/Thing
+4041	ADVICE	Speech and language	Advice (opinion), an opinion or recommendation offered as a guide to action, conduct	Person/Thing
+4042	FORMES FOMENTARIUS	Agriculture and Vegetation	Commonly known as the tinder fungus, false tinder fungus, hoof fungus, tinder conk, tinder polypore or ice man fungus is a species of fungal plant pathogen found in Europe, Asia, Africa and North America	Person/Thing
+4043	ARABLE LAND	Agriculture and Vegetation	Any land capable of being ploughed and used to grow crops	Person/Thing
+4044	BUNIAS ORIENTALIS	Agriculture and Vegetation	Turkish wartycabbage, warty-cabbage, hill mustard, or Turkish rocket, is a edible wild plant species in the genus Bunias. It is classified as an invasive neophyte in most of Middle Europe and parts of North America	Person/Thing
+4045	VEGETATE (HUMANS)	Basic actions and technology	To live or spend a period of time in a dull, inactive, unchallenging way	Action/Process
+4046	HALL	The house	Relatively large space enclosed by a roof and walls	Person/Thing
+4047	SCUTCH	Agriculture and Vegetation	Wooden implement shaped like a large knife used to separate the valuable fibres of flax or hemp by beating them and scraping from it the woody or coarse portions	Person/Thing
+4048	HORSERADISH	Agriculture and Vegetation	Armoracia rusticana, syn. Cochlearia armoracia is a perennial plant of the family Brassicaceae	Person/Thing
+4049	PEAT	Agriculture and Vegetation	Also known as turf, is an accumulation of partially decayed vegetation or organic matter	Person/Thing
+4050	COTTAGE CHEESE	Food and drink	Curdled milk product with a mild flavor and a creamy, non-homogeneous, soupy texture. It is also known as curds and whey	Person/Thing
+4051	TURUL	Religion and belief	Mythological bird of prey, mostly depicted as a Falcon, in Hungarian tradition and Turkic tradition, and a national symbol of Hungarians	Person/Thing
+4052	BUSTARD	Animals	Large, terrestrial birds living mainly in dry grassland areas and on the steppes of the Old World	Person/Thing
+4053	ROLL UP	Basic actions and technology	Make something into a particular shape, especially cylindrical or fold-like	Action/Process
+4054	HEIFER	Animals	Young cow before she has had her first calf	Person/Thing
+4055	GROUND SQUIRREL	Animals	Members of the squirrel family of rodents (Sciuridae), which generally live on or in the ground, rather than trees	Person/Thing
+4056	FISHWEIR	Warfare and hunting	Obstruction placed in tidal waters, or wholly or partially across a river, to trap fish or hinder their passage	Person/Thing
+4057	ICE HOLE	Warfare and hunting	A hole cut in ice for fishing	Person/Thing
+4058	GABLE	The house	Generally triangular portion of a wall between the edges of intersecting roof pitches	Person/Thing
+4059	CHAMOIS	Animals	Rupicapra rupicapra is a species of goat-antelope native to mountains in Europe, from west to east, including the Alps, the Dinarides, the Tatra and the Carpathian Mountains, the Balkan Mountains, the Rila–Rhodope massif, Pindus, the northeastern mountains of Turkey, and the Caucasus	Person/Thing  

--- a/concepticondata/concepticon.tsv
+++ b/concepticondata/concepticon.tsv
@@ -3959,87 +3959,87 @@ ID	GLOSS	SEMANTICFIELD	DEFINITION	ONTOLOGICAL_CATEGORY	REPLACEMENT_ID
 3973	DEPRESSED	Emotions and values	A mental state of despondency, unhappinness, or hopelessness.	Property	
 3974	UNHAPPY	Emotions and values	Feeling not cheerful or glad, sometimes due to a misfortune.	Property	
 3975	NERVOUS	Emotions and values	A mental state of nervousness or agitation. Also, being easily excited or irritated.	Property	
-3976	PIEBALD	Animals	Pattern of unpigmented spots (white) on a pigmented background of hair, feathers or scales	Property
-3977	GANTRY	Basic actions and technology	Overhead bridge-like structure supporting equipment such as a crane, signals, or cameras.	Person/Thing
-3978	CHARISMA	Religion and belief	Compelling attractiveness or charm that can inspire devotion in others	Person/Thing
-3979	BAN (TITLE)	Social and political relations	Noble title used in several states in Central and Southeastern Europe between the 7th century and the 20th century	Person/Thing
-3980	HAIRY	The body	People or animals covered in hairs or fur	Property
-3981	LABEL	Law	Piece of paper, plastic film, cloth, metal, or other material affixed to a container or product, on which is written or printed information or symbols about the product or item	Person/Thing
-3982	VELVET	Clothing and grooming	Type of woven tufted fabric in which the cut threads are evenly distributed, with a short pile, giving it a distinctive soft feel	Person/Thing
-3983	LEGCUFFS	Law	Physical restraints used on the ankles of a person to allow walking only with a restricted stride and to prevent running and effective physical resistance	Person/Thing
-3984	ARCTIUM	Agriculture and Vegetation	Genus of biennial plants commonly known as burdock, family Asteraceae.[2] Native to Europe and Asia, several species have been widely introduced worldwide.[3] Burdock's clinging properties, in addition to thus providing an excellent mechanism for seed dispersal, led to the invention of the hook and loop fastener.	Person/Thing
-3985	STUB	The physical world	Shortened objects and entities	Person/Thing
-3986	MAGICAL	Religion and belief	Of, relating to, or by means of magic	Property
-3987	EUPHORBIA	Agriculture and Vegetation	very large and diverse genus of flowering plants, commonly called spurge, in the spurge family	Person/Thing
-3988	FASTENER	Basic actions and technology	Hardware device that mechanically joins or affixes two or more objects together	Person/Thing
-3989	RHEUM	The body	Thin mucus naturally discharged from the eyes, nose, or mouth, often during sleep	Person/Thing
-3990	BANQUET	Religion and belief	Formal large meal or feast, where a number of people consume food together.	Person/Thing
-3991	COURIER	Social and political relations	Person or organisation that delivers a message, package or letter from one place or person to another place or person.	Person/Thing
-3992	GRIST	Agriculture and Vegetation	Grain that has been separated from its chaff in preparation for grinding	Person/Thing
-3993	WEDGE	Basic actions and technology	Triangular shaped tool, and is a portable inclined plane, and one of the six simple machines	Person/Thing
-3994	ATONE	Law	Taking action to correct previous wrongdoing on their part, either through direct action to undo the consequences of that act, equivalent action to do good for others, or some other expression of feelings of remorse	Action/Process
-3995	MERIT	Possession	A claim to commendation or a reward	Person/Thing
-3996	MORALITY	Religion and belief	Differentiation of intentions, decisions and actions between those that are distinguished as proper (right) and those that are improper (wrong)	Person/Thing
-3997	POLECAT	Animals	Common name for mammals in the order Carnivora and subfamilies Ictonychinae and Mustelinae	Person/Thing
-3998	MATCHMAKER	Social and political relations	Someone who finds suitable dates or marriage partners for other people	Person/Thing
-3999	STEPPE MOUSE	Animals	Species of rodent in the family Muridae	Person/Thing
-4000	BULRUSH	Agriculture and Vegetation	Vernacular name for several large wetland grass-like plants (Cyperaceae, Typhaceae)	Person/Thing
-4001	REIN	Animals	Items of horse tack, used to direct a horse or other animal used for riding	Person/Thing
-4002	BORDERLAND	Social and political relations	Geographical space or zone around a territorial border	Person/Thing
-4003	HORNBEAM	Agriculture and Vegetation	Hardwood trees in the flowering plant genus Carpinus in the birch family Betulaceae	Person/Thing
-4004	CONFESS	Law	To admit to the truth, particularly in the context of sins or crimes committed	Person/Thing
-4005	CUDWEED	Agriculture and Vegetation	Any of many of species of flowering plants in family Asteraceae	Person/Thing
-4006	THIMBLE	Clothing and grooming	Small pitted cup worn on the finger that protects it from being pricked or poked by a needle while sewing	Person/Thing
-4007	MORAL	Religion and belief	Conforming to a standard of right behaviour; sanctioned by or operative on one's conscience or ethical judgment	Person/Thing
-4008	SUITABLE	Miscellaneous function words	Having sufficient or the required properties for a certain purpose or task; appropriate to a certain occasion	Person/Thing
-4009	BUTTERMILK	Food and drink	Fermented dairy drink. Traditionally, it was the liquid left behind after churning butter out of cultured cream	Person/Thing
-4010	DO-LITTLE	Social and political relations	Lazy person; one who does little but does not admit to it	Person/Thing
-4011	STRATIOTES ALOIDES	Agriculture and Vegetation	Commonly known as water soldiers or water pineapple, is a submerged aquatic plant native to Europe and northwestern Asia	Person/Thing
-4012	ACER TATRICUM	Agriculture and Vegetation	Tatar maple or Tatarian maple, is a species of maple widespread across central and southeastern Europe and temperate Asia, from Austria and Turkey east as far as Japan and the Russian Far East	Person/Thing
-4013	MAN OF GRIT	Social and political relations	Man with strength of mind, great courage or fearlessness, fortitude.	Person/Thing
-4014	CHICORY	Agriculture and Vegetation	Somewhat woody, perennial herbaceous plant of the family Asteraceae, usually with bright blue flowers, rarely white or pink	Person/Thing
-4015	MERCURY	Basic actions and technology	Chemical element with the symbol Hg and atomic number 80. It is also known as quicksilver and was formerly named hydrargyrum	Person/Thing
-4016	STOOK	Agriculture and Vegetation	Arrangement of sheaves of cut grain-stalks placed so as to keep the grain-heads off the ground while still in the field and prior to collection for threshing	Person/Thing
-4017	CUD	Agriculture and Vegetation	Portion of food that returns from a ruminant's stomach to the mouth to be chewed for the second time	Person/Thing
-4018	TIMOTHY (GRASS)	Agriculture and Vegetation	Abundant perennial grass native to most of Europe except for the Mediterranean region	Person/Thing
-4019	KOMONDOR	Animals	Also known as the Hungarian sheepdog, is a large, white-coloured Hungarian breed of livestock guardian dog with a long, corded coat	Person/Thing
-4020	BLACKTHORN	Agriculture and Vegetation	Species of flowering plant in the rose family Rosaceae. The species is native to Europe, western Asia, and locally in northwest Africa	Person/Thing
-4021	LOAN	Possession	Lending of money by one or more individuals, organizations, or other entities to other individuals, organizations etc	Person/Thing
-4022	PICUS VIRIDIS	Animals	Large green woodpecker with a bright red crown and a black moustache	Person/Thing
-4023	GOBIO GOBIO	Animals	Or the gudgeon, is a species of fish in the family Cyprinidae. This small fish is widely distributed in fresh-water streams and lakes across central and temperate Eurasia	Person/Thing
-4024	PEN (ENCLOSURE)	Animals	Enclosure for holding livestock. It may also perhaps be used as a term for an enclosure for other animals such as pets that are unwanted inside the house	Person/Thing
-4025	CRUMB	Food and drink	small piece which breaks off from baked food (such as cake, biscuit or bread)	Person/Thing
-4026	POINT (TABLE GAMES)	Social and political relations	Any one of the triangular spaces on a tables board	Person/Thing
-4027	STITCH	Clothing and grooming	To form stitches in; especially, to sew in such a manner as to show on the surface a continuous line of stitches	Action/Process
-4028	ETERNAL	Religion and belief	Lasting forever; unending	Person/Thing
-4029	BECOME MAD	Cognition	To grow crazy	Action/Process
-4030	ORNITHOGALUM	Agriculture and Vegetation	Genus of perennial plants mostly native to southern Europe and southern Africa belonging to the family Asparagaceae	Person/Thing
-4031	LEES	Agriculture and Vegetation	Deposits of dead yeast or residual yeast and other particles that precipitate, or are carried by the action of fining, to the bottom of a vat of wine after fermentation and aging	Person/Thing
-4032	CORNUS	Agriculture and Vegetation	Genus of about 30–60 species of woody plants in the family Cornaceae, commonly known as dogwoods, which can generally be distinguished by their blossoms, berries, and distinctive bark	Person/Thing
-4033	STIZOSTEDION LUCIOPERCA	Animals	The zander, sander or pikeperch, is a species of ray-finned fish from the family Percidae, which includes the perches, ruffes and darters	Person/Thing
-4034	SCURVY	The body	Disease resulting from a lack of vitamin C (ascorbic acid)	Person/Thing
-4035	MIRAGE	The physical world	Naturally-occurring optical phenomenon in which light rays bend via refraction to produce a displaced image of distant objects or the sky	Person/Thing
-4036	TROUSSEAU BOX	Basic actions and technology	Man made object that contains clothes and linen, etc., that a bride collects or that is given to her for her wedding and married life, especially a traditional or formal set of these	Person/Thing
-4037	GROCER	Social and political relations	Person who retails groceries (foodstuffs and household items) from a grocery	Person/Thing
-4038	SLUMBER	The body	Very light state of sleep, almost awake	Person/Thing
-4039	GYRFALCON	Animals	Largest of the falcon species, is a bird of prey. The abbreviation gyr is also used.[4] It breeds on Arctic coasts and tundra, and the islands of northern North America and the Eurosiberian region	Person/Thing
-4040	FURRIER	Social and political relations	Person who sells, makes, repairs, alters, cleans, or otherwise deals in clothing made of fur	Person/Thing
-4041	ADVICE	Speech and language	Advice (opinion), an opinion or recommendation offered as a guide to action, conduct	Person/Thing
-4042	FORMES FOMENTARIUS	Agriculture and Vegetation	Commonly known as the tinder fungus, false tinder fungus, hoof fungus, tinder conk, tinder polypore or ice man fungus is a species of fungal plant pathogen found in Europe, Asia, Africa and North America	Person/Thing
-4043	ARABLE LAND	Agriculture and Vegetation	Any land capable of being ploughed and used to grow crops	Person/Thing
-4044	BUNIAS ORIENTALIS	Agriculture and Vegetation	Turkish wartycabbage, warty-cabbage, hill mustard, or Turkish rocket, is a edible wild plant species in the genus Bunias. It is classified as an invasive neophyte in most of Middle Europe and parts of North America	Person/Thing
-4045	VEGETATE (HUMANS)	Basic actions and technology	To live or spend a period of time in a dull, inactive, unchallenging way	Action/Process
-4046	HALL	The house	Relatively large space enclosed by a roof and walls	Person/Thing
-4047	SCUTCH	Agriculture and Vegetation	Wooden implement shaped like a large knife used to separate the valuable fibres of flax or hemp by beating them and scraping from it the woody or coarse portions	Person/Thing
-4048	HORSERADISH	Agriculture and Vegetation	Armoracia rusticana, syn. Cochlearia armoracia is a perennial plant of the family Brassicaceae	Person/Thing
-4049	PEAT	Agriculture and Vegetation	Also known as turf, is an accumulation of partially decayed vegetation or organic matter	Person/Thing
-4050	COTTAGE CHEESE	Food and drink	Curdled milk product with a mild flavor and a creamy, non-homogeneous, soupy texture. It is also known as curds and whey	Person/Thing
-4051	TURUL	Religion and belief	Mythological bird of prey, mostly depicted as a Falcon, in Hungarian tradition and Turkic tradition, and a national symbol of Hungarians	Person/Thing
-4052	BUSTARD	Animals	Large, terrestrial birds living mainly in dry grassland areas and on the steppes of the Old World	Person/Thing
-4053	ROLL UP	Basic actions and technology	Make something into a particular shape, especially cylindrical or fold-like	Action/Process
-4054	HEIFER	Animals	Young cow before she has had her first calf	Person/Thing
-4055	GROUND SQUIRREL	Animals	Members of the squirrel family of rodents (Sciuridae), which generally live on or in the ground, rather than trees	Person/Thing
-4056	FISHWEIR	Warfare and hunting	Obstruction placed in tidal waters, or wholly or partially across a river, to trap fish or hinder their passage	Person/Thing
-4057	ICE HOLE	Warfare and hunting	A hole cut in ice for fishing	Person/Thing
-4058	GABLE	The house	Generally triangular portion of a wall between the edges of intersecting roof pitches	Person/Thing
-4059	CHAMOIS	Animals	Rupicapra rupicapra is a species of goat-antelope native to mountains in Europe, from west to east, including the Alps, the Dinarides, the Tatra and the Carpathian Mountains, the Balkan Mountains, the Rila–Rhodope massif, Pindus, the northeastern mountains of Turkey, and the Caucasus	Person/Thing  
+3976	"PIEBALD"	"Animals"	"Pattern of unpigmented spots (white) on a pigmented background of hair, feathers or scales"	"Property"	
+3977	"GANTRY"	"Basic actions and technology"	"Overhead bridge-like structure supporting equipment such as a crane, signals, or cameras."	"Person/Thing"	
+3978	"CHARISMA"	"Religion and belief"	"Compelling attractiveness or charm that can inspire devotion in others"	"Person/Thing"	
+3979	"BAN (TITLE)"	"Social and political relations"	"Noble title used in several states in Central and Southeastern Europe between the 7th century and the 20th century"	"Person/Thing"	
+3980	"HAIRY"	"The body"	"People or animals covered in hairs or fur"	"Property"	
+3981	"LABEL"	"Law"	"Piece of paper, plastic film, cloth, metal, or other material affixed to a container or product, on which is written or printed information or symbols about the product or item"	"Person/Thing"	
+3982	"VELVET"	"Clothing and grooming"	"Type of woven tufted fabric in which the cut threads are evenly distributed, with a short pile, giving it a distinctive soft feel"	"Person/Thing"	
+3983	"LEGCUFFS"	"Law"	"Physical restraints used on the ankles of a person to allow walking only with a restricted stride and to prevent running and effective physical resistance"	"Person/Thing"	
+3984	"ARCTIUM"	"Agriculture and Vegetation"	"Genus of biennial plants commonly known as burdock, family Asteraceae.[2] Native to Europe and Asia, several species have been widely introduced worldwide.[3] Burdock's clinging properties, in addition to thus providing an excellent mechanism for seed dispersal, led to the invention of the hook and loop fastener."	"Person/Thing"	
+3985	"STUB"	"The physical world"	"Shortened objects and entities"	"Person/Thing"	
+3986	"MAGICAL"	"Religion and belief"	"Of, relating to, or by means of magic"	"Property"	
+3987	"EUPHORBIA"	"Agriculture and Vegetation"	"very large and diverse genus of flowering plants, commonly called spurge, in the spurge family"	"Person/Thing"	
+3988	"FASTENER"	"Basic actions and technology"	"Hardware device that mechanically joins or affixes two or more objects together"	"Person/Thing"	
+3989	"RHEUM"	"The body"	"Thin mucus naturally discharged from the eyes, nose, or mouth, often during sleep"	"Person/Thing"	
+3990	"BANQUET"	"Religion and belief"	"Formal large meal or feast, where a number of people consume food together."	"Person/Thing"	
+3991	"COURIER"	"Social and political relations"	"Person or organisation that delivers a message, package or letter from one place or person to another place or person."	"Person/Thing"	
+3992	"GRIST"	"Agriculture and Vegetation"	"Grain that has been separated from its chaff in preparation for grinding"	"Person/Thing"	
+3993	"WEDGE"	"Basic actions and technology"	"Triangular shaped tool, and is a portable inclined plane, and one of the six simple machines"	"Person/Thing"	
+3994	"ATONE"	"Law"	"Taking action to correct previous wrongdoing on their part, either through direct action to undo the consequences of that act, equivalent action to do good for others, or some other expression of feelings of remorse"	"Action/Process"	
+3995	"MERIT"	"Possession"	"A claim to commendation or a reward"	"Person/Thing"	
+3996	"MORALITY"	"Religion and belief"	"Differentiation of intentions, decisions and actions between those that are distinguished as proper (right) and those that are improper (wrong)"	"Person/Thing"	
+3997	"POLECAT"	"Animals"	"Common name for mammals in the order Carnivora and subfamilies Ictonychinae and Mustelinae"	"Person/Thing"	
+3998	"MATCHMAKER"	"Social and political relations"	"Someone who finds suitable dates or marriage partners for other people"	"Person/Thing"	
+3999	"STEPPE MOUSE"	"Animals"	"Species of rodent in the family Muridae"	"Person/Thing"	
+4000	"BULRUSH"	"Agriculture and Vegetation"	"Vernacular name for several large wetland grass-like plants (Cyperaceae, Typhaceae)"	"Person/Thing"	
+4001	"REIN"	"Animals"	"Items of horse tack, used to direct a horse or other animal used for riding"	"Person/Thing"	
+4002	"BORDERLAND"	"Social and political relations"	"Geographical space or zone around a territorial border"	"Person/Thing"	
+4003	"HORNBEAM"	"Agriculture and Vegetation"	"Hardwood trees in the flowering plant genus Carpinus in the birch family Betulaceae"	"Person/Thing"	
+4004	"CONFESS"	"Law"	"To admit to the truth, particularly in the context of sins or crimes committed"	"Person/Thing"	
+4005	"CUDWEED"	"Agriculture and Vegetation"	"Any of many of species of flowering plants in family Asteraceae"	"Person/Thing"	
+4006	"THIMBLE"	"Clothing and grooming"	"Small pitted cup worn on the finger that protects it from being pricked or poked by a needle while sewing"	"Person/Thing"	
+4007	"MORAL"	"Religion and belief"	"Conforming to a standard of right behaviour; sanctioned by or operative on one's conscience or ethical judgment"	"Person/Thing"	
+4008	"SUITABLE"	"Miscellaneous function words"	"Having sufficient or the required properties for a certain purpose or task; appropriate to a certain occasion"	"Person/Thing"	
+4009	"BUTTERMILK"	"Food and drink"	"Fermented dairy drink. Traditionally, it was the liquid left behind after churning butter out of cultured cream"	"Person/Thing"	
+4010	"DO-LITTLE"	"Social and political relations"	"Lazy person; one who does little but does not admit to it"	"Person/Thing"	
+4011	"STRATIOTES ALOIDES"	"Agriculture and Vegetation"	"Commonly known as water soldiers or water pineapple, is a submerged aquatic plant native to Europe and northwestern Asia"	"Person/Thing"	
+4012	"ACER TATRICUM"	"Agriculture and Vegetation"	"Tatar maple or Tatarian maple, is a species of maple widespread across central and southeastern Europe and temperate Asia, from Austria and Turkey east as far as Japan and the Russian Far East"	"Person/Thing"	
+4013	"MAN OF GRIT"	"Social and political relations"	"Man with strength of mind, great courage or fearlessness, fortitude."	"Person/Thing"	
+4014	"CHICORY"	"Agriculture and Vegetation"	"Somewhat woody, perennial herbaceous plant of the family Asteraceae, usually with bright blue flowers, rarely white or pink"	"Person/Thing"	
+4015	"MERCURY"	"Basic actions and technology"	"Chemical element with the symbol Hg and atomic number 80. It is also known as quicksilver and was formerly named hydrargyrum"	"Person/Thing"	
+4016	"STOOK"	"Agriculture and Vegetation"	"Arrangement of sheaves of cut grain-stalks placed so as to keep the grain-heads off the ground while still in the field and prior to collection for threshing"	"Person/Thing"	
+4017	"CUD"	"Agriculture and Vegetation"	"Portion of food that returns from a ruminant's stomach to the mouth to be chewed for the second time"	"Person/Thing"	
+4018	"TIMOTHY (GRASS)"	"Agriculture and Vegetation"	"Abundant perennial grass native to most of Europe except for the Mediterranean region"	"Person/Thing"	
+4019	"KOMONDOR"	"Animals"	"Also known as the Hungarian sheepdog, is a large, white-coloured Hungarian breed of livestock guardian dog with a long, corded coat"	"Person/Thing"	
+4020	"BLACKTHORN"	"Agriculture and Vegetation"	"Species of flowering plant in the rose family Rosaceae. The species is native to Europe, western Asia, and locally in northwest Africa"	"Person/Thing"	
+4021	"LOAN"	"Possession"	"Lending of money by one or more individuals, organizations, or other entities to other individuals, organizations etc"	"Person/Thing"	
+4022	"PICUS VIRIDIS"	"Animals"	"Large green woodpecker with a bright red crown and a black moustache"	"Person/Thing"	
+4023	"GOBIO GOBIO"	"Animals"	"Or the gudgeon, is a species of fish in the family Cyprinidae. This small fish is widely distributed in fresh-water streams and lakes across central and temperate Eurasia"	"Person/Thing"	
+4024	"PEN (ENCLOSURE)"	"Animals"	"Enclosure for holding livestock. It may also perhaps be used as a term for an enclosure for other animals such as pets that are unwanted inside the house"	"Person/Thing"	
+4025	"CRUMB"	"Food and drink"	"small piece which breaks off from baked food (such as cake, biscuit or bread)"	"Person/Thing"	
+4026	"POINT (TABLE GAMES)"	"Social and political relations"	"Any one of the triangular spaces on a tables board"	"Person/Thing"	
+4027	"STITCH"	"Clothing and grooming"	"To form stitches in; especially, to sew in such a manner as to show on the surface a continuous line of stitches"	"Action/Process"	
+4028	"ETERNAL"	"Religion and belief"	"Lasting forever; unending"	"Person/Thing"	
+4029	"BECOME MAD"	"Cognition"	"To grow crazy"	"Action/Process"	
+4030	"ORNITHOGALUM"	"Agriculture and Vegetation"	"Genus of perennial plants mostly native to southern Europe and southern Africa belonging to the family Asparagaceae"	"Person/Thing"	
+4031	"LEES"	"Agriculture and Vegetation"	"Deposits of dead yeast or residual yeast and other particles that precipitate, or are carried by the action of ""fining"", to the bottom of a vat of wine after fermentation and aging"	"Person/Thing"	
+4032	"CORNUS"	"Agriculture and Vegetation"	"Genus of about 30–60 species of woody plants in the family Cornaceae, commonly known as dogwoods, which can generally be distinguished by their blossoms, berries, and distinctive bark"	"Person/Thing"	
+4033	"STIZOSTEDION LUCIOPERCA"	"Animals"	"The zander, sander or pikeperch, is a species of ray-finned fish from the family Percidae, which includes the perches, ruffes and darters"	"Person/Thing"	
+4034	"SCURVY"	"The body"	"Disease resulting from a lack of vitamin C (ascorbic acid)"	"Person/Thing"	
+4035	"MIRAGE"	"The physical world"	"Naturally-occurring optical phenomenon in which light rays bend via refraction to produce a displaced image of distant objects or the sky"	"Person/Thing"	
+4036	"TROUSSEAU BOX"	"Basic actions and technology"	"Man made object that contains clothes and linen, etc., that a bride collects or that is given to her for her wedding and married life, especially a traditional or formal set of these"	"Person/Thing"	
+4037	"GROCER"	"Social and political relations"	"Person who retails groceries (foodstuffs and household items) from a grocery"	"Person/Thing"	
+4038	"SLUMBER"	"The body"	"Very light state of sleep, almost awake"	"Person/Thing"	
+4039	"GYRFALCON"	"Animals"	"Largest of the falcon species, is a bird of prey. The abbreviation gyr is also used.[4] It breeds on Arctic coasts and tundra, and the islands of northern North America and the Eurosiberian region"	"Person/Thing"	
+4040	"FURRIER"	"Social and political relations"	"Person who sells, makes, repairs, alters, cleans, or otherwise deals in clothing made of fur"	"Person/Thing"	
+4041	"ADVICE"	"Speech and language"	"Advice (opinion), an opinion or recommendation offered as a guide to action, conduct"	"Person/Thing"	
+4042	"FORMES FOMENTARIUS"	"Agriculture and Vegetation"	"Commonly known as the tinder fungus, false tinder fungus, hoof fungus, tinder conk, tinder polypore or ice man fungus is a species of fungal plant pathogen found in Europe, Asia, Africa and North America"	"Person/Thing"	
+4043	"ARABLE LAND"	"Agriculture and Vegetation"	"Any land capable of being ploughed and used to grow crops"	"Person/Thing"	
+4044	"BUNIAS ORIENTALIS"	"Agriculture and Vegetation"	"Turkish wartycabbage, warty-cabbage, hill mustard, or Turkish rocket, is a edible wild plant species in the genus Bunias. It is classified as an invasive neophyte in most of Middle Europe and parts of North America"	"Person/Thing"	
+4045	"VEGETATE (HUMANS)"	"Basic actions and technology"	"To live or spend a period of time in a dull, inactive, unchallenging way"	"Action/Process"	
+4046	"HALL"	"The house"	"Relatively large space enclosed by a roof and walls"	"Person/Thing"	
+4047	"SCUTCH"	"Agriculture and Vegetation"	"Wooden implement shaped like a large knife used to separate the valuable fibres of flax or hemp by beating them and scraping from it the woody or coarse portions"	"Person/Thing"	
+4048	"HORSERADISH"	"Agriculture and Vegetation"	"Armoracia rusticana, syn. Cochlearia armoracia is a perennial plant of the family Brassicaceae"	"Person/Thing"	
+4049	"PEAT"	"Agriculture and Vegetation"	"Also known as turf, is an accumulation of partially decayed vegetation or organic matter"	"Person/Thing"	
+4050	"COTTAGE CHEESE"	"Food and drink"	"Curdled milk product with a mild flavor and a creamy, non-homogeneous, soupy texture. It is also known as curds and whey"	"Person/Thing"	
+4051	"TURUL"	"Religion and belief"	"Mythological bird of prey, mostly depicted as a Falcon, in Hungarian tradition and Turkic tradition, and a national symbol of Hungarians"	"Person/Thing"	
+4052	"BUSTARD"	"Animals"	"Large, terrestrial birds living mainly in dry grassland areas and on the steppes of the Old World"	"Person/Thing"	
+4053	"ROLL UP"	"Basic actions and technology"	"Make something into a particular shape, especially cylindrical or fold-like"	"Action/Process"	
+4054	"HEIFER"	"Animals"	"Young cow before she has had her first calf"	"Person/Thing"	
+4055	"GROUND SQUIRREL"	"Animals"	"Members of the squirrel family of rodents (Sciuridae), which generally live on or in the ground, rather than trees"	"Person/Thing"	
+4056	"FISHWEIR"	"Warfare and hunting"	"Obstruction placed in tidal waters, or wholly or partially across a river, to trap fish or hinder their passage"	"Person/Thing"	
+4057	"ICE HOLE"	"Warfare and hunting"	"A hole cut in ice for fishing"	"Person/Thing"	
+4058	"GABLE"	"The house"	"Generally triangular portion of a wall between the edges of intersecting roof pitches"	"Person/Thing"	
+4059	"CHAMOIS"	"Animals"	"Rupicapra rupicapra is a species of goat-antelope native to mountains in Europe, from west to east, including the Alps, the Dinarides, the Tatra and the Carpathian Mountains, the Balkan Mountains, the Rila–Rhodope massif, Pindus, the northeastern mountains of Turkey, and the Caucasus"	"Person/Thing"	

--- a/concepticondata/concepticon.tsv
+++ b/concepticondata/concepticon.tsv
@@ -4014,7 +4014,7 @@ ID	GLOSS	SEMANTICFIELD	DEFINITION	ONTOLOGICAL_CATEGORY	REPLACEMENT_ID
 4028	ETERNAL	Religion and belief	Lasting forever; unending	Person/Thing
 4029	BECOME MAD	Cognition	To grow crazy	Action/Process
 4030	ORNITHOGALUM	Agriculture and Vegetation	Genus of perennial plants mostly native to southern Europe and southern Africa belonging to the family Asparagaceae	Person/Thing
-4031	LEES	Agriculture and Vegetation	Deposits of dead yeast or residual yeast and other particles that precipitate, or are carried by the action of "fining", to the bottom of a vat of wine after fermentation and aging	Person/Thing
+4031	LEES	Agriculture and Vegetation	Deposits of dead yeast or residual yeast and other particles that precipitate, or are carried by the action of fining, to the bottom of a vat of wine after fermentation and aging	Person/Thing
 4032	CORNUS	Agriculture and Vegetation	Genus of about 30–60 species of woody plants in the family Cornaceae, commonly known as dogwoods, which can generally be distinguished by their blossoms, berries, and distinctive bark	Person/Thing
 4033	STIZOSTEDION LUCIOPERCA	Animals	The zander, sander or pikeperch, is a species of ray-finned fish from the family Percidae, which includes the perches, ruffes and darters	Person/Thing
 4034	SCURVY	The body	Disease resulting from a lack of vitamin C (ascorbic acid)	Person/Thing


### PR DESCRIPTION
After this, I will submit the actual concept list and fulfil the other bullets of the check list.
I'm not sure a how to apply the  `concepticon notlinked --gloss "NEW_GLOSS"` function, could need some help with that. I only checked with crtl+f to make sure these concepts are not in the list yet.

# Pull request checklist

- [ ] add new concept list
- [ ] add new metadata
- [x] add new Concepticon concept sets
  * [ ] checked whether the new concept(s) can be applied to existing lists with
    `concepticon notlinked --gloss "NEW_GLOSS"`
- [ ] add new Concepticon concept relations
- [ ] refine existing Concepticon concept set mappings
- [ ] refine Concepticon glosses
- [ ] refine Concepticon concept relations
- [ ] refine Concepticon concept definitions
- [ ] retire data

## Additional information

...
