### PR TITLE
fix rows for new concepts

### DIFF
--- a/concepticondata/concepticon.tsv
+++ b/concepticondata/concepticon.tsv
@@ -3962,7 +3962,7 @@ ID	GLOSS	SEMANTICFIELD	DEFINITION	ONTOLOGICAL_CATEGORY	REPLACEMENT_ID
 3976	EXPLODE	Basic actions and technology	To burst violently as a result of internal pressure.	Action/Process	
 3977	SHINY	Sense perception	Property of a surface that is bright from reflected light.	Property	
 3978	COMPANION	Social and political relations	One who accompanies or associates with another, either habitually or casually.	Person/Thing	
-3979	TADPOLE	Animals	Larval stage of amphibians.	Person/Thing
-3980	GET DRUNK	Basic actions and technology	Activity of drinking alcoholic beverages that leads to having an altered conciousness.	Action/Process
-3981	GUAVA	The physical world	Fruit from the myrtle family, native to Latin America.	Person/Thing
-3982	BREEZE	The physical world	A gentle to moderate wind.	Person/Thing
+3979	TADPOLE	Animals	Larval stage of amphibians.	Person/Thing	
+3980	GET DRUNK	Basic actions and technology	Activity of drinking alcoholic beverages that leads to having an altered conciousness.	Action/Process	
+3981	GUAVA	The physical world	Fruit from the myrtle family, native to Latin America.	Person/Thing	
+3982	BREEZE	The physical world	A gentle to moderate wind.	Person/Thing	


### PR DESCRIPTION
# Pull request checklist

- [ ] add new concept list
- [ ] add new metadata
- [ ] add new Concepticon concept sets
  * [ ] checked whether the new concept(s) can be applied to existing lists with
    `concepticon notlinked --gloss "NEW_GLOSS"`
- [ ] add new Concepticon concept relations
- [ ] refine existing Concepticon concept set mappings
- [ ] refine Concepticon glosses
- [ ] refine Concepticon concept relations
- [ ] refine Concepticon concept definitions
- [ ] retire data

## Additional information

Not sure which category this fits in. As commented in the last PR (#1292 ) which is already merged, the new concepts miss the empty sixth row. This PR fixes this. Here is the comment: https://github.com/concepticon/concepticon-data/pull/1292#issuecomment-1782795158

This is not captured by the `concepticon test`, but I also don't know if this actually breaks anything. Probably still safer to fix this. @xrotwang or @AnnikaTjuka Could you briefly check if everything is okay?
